### PR TITLE
BreadcrumbとThreadHoldingを削除

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -65,6 +65,6 @@
               "CMAKE_BUILD_TYPE": "Release",
               "KAGGLE": "1"
             }
-        },
+        }
     ]
 }

--- a/fide2024/ucioption.cpp
+++ b/fide2024/ucioption.cpp
@@ -63,7 +63,7 @@ void init(OptionsMap& o) {
 #endif // !KAGGLE
   o["Contempt"]              << Option(24, -100, 100);
   o["Analysis Contempt"]     << Option("Both var Off var White var Black var Both", "Both");
-  o["Threads"]               << Option(1, 1, 512, on_threads);
+  o["Threads"]               << Option(1, 1, 1, on_threads);
   o["Hash"]                  << Option(16, 1, MaxHashMB, on_hash_size);
   o["Clear Hash"]            << Option(on_clear_hash);
   o["Ponder"]                << Option(false);


### PR DESCRIPTION
探索スレッドをシングルスレッドにする場合には必要がないから、実行ファイルのサイズを減らすためにBreadcrumbとThreadHoldingを削除を削除した