### PR TITLE
ucioptionを定数に変更した

### DIFF
--- a/fide2024/benchmark.cpp
+++ b/fide2024/benchmark.cpp
@@ -34,7 +34,7 @@ using namespace std;
 namespace {
 
 const vector<string> Defaults = {
-  "setoption name UCI_Chess960 value false",
+  //"setoption name UCI_Chess960 value false",
   "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
   "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 10",
   "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 11",
@@ -89,10 +89,10 @@ const vector<string> Defaults = {
   "8/8/8/8/8/6k1/6p1/6K1 w - -",
   "7k/7P/6K1/8/3B4/8/8/8 b - -",
 
-  // Chess 960
-  "setoption name UCI_Chess960 value true",
-  "bbqnnrkr/pppppppp/8/8/8/8/PPPPPPPP/BBQNNRKR w KQkq - 0 1 moves g2g3 d7d5 d2d4 c8h3 c1g5 e8d6 g5e7 f7f6",
-  "setoption name UCI_Chess960 value false"
+  //// Chess 960
+  //"setoption name UCI_Chess960 value true",
+  //"bbqnnrkr/pppppppp/8/8/8/8/PPPPPPPP/BBQNNRKR w KQkq - 0 1 moves g2g3 d7d5 d2d4 c8h3 c1g5 e8d6 g5e7 f7f6",
+  //"setoption name UCI_Chess960 value false"
 };
 
 } // namespace
@@ -147,8 +147,8 @@ vector<string> setup_bench(const Position& current, istream& is) {
       file.close();
   }
 
-  list.emplace_back("setoption name Threads value " + threads);
-  list.emplace_back("setoption name Hash value " + ttSize);
+  //list.emplace_back("setoption name Threads value " + threads);
+  //list.emplace_back("setoption name Hash value " + ttSize);
   list.emplace_back("ucinewgame");
 
   for (const string& fen : fens)

--- a/fide2024/evaluate.cpp
+++ b/fide2024/evaluate.cpp
@@ -317,19 +317,6 @@ namespace {
                 // Bonus for bishop on a long diagonal which can "see" both center squares
                 if (more_than_one(attacks_bb<BISHOP>(s, pos.pieces(PAWN)) & Center))
                     score += LongDiagonalBishop;
-
-                // An important Chess960 pattern: a cornered bishop blocked by a friendly
-                // pawn diagonally in front of it is a very serious problem, especially
-                // when that pawn is also blocked.
-                if (   pos.is_chess960()
-                    && (s == relative_square(Us, SQ_A1) || s == relative_square(Us, SQ_H1)))
-                {
-                    Direction d = pawn_push(Us) + (file_of(s) == FILE_A ? EAST : WEST);
-                    if (pos.piece_on(s + d) == make_piece(Us, PAWN))
-                        score -= !pos.empty(s + d + pawn_push(Us))                ? CorneredBishop * 4
-                                : pos.piece_on(s + d + d) == make_piece(Us, PAWN) ? CorneredBishop * 2
-                                                                                  : CorneredBishop;
-                }
             }
         }
 

--- a/fide2024/main.cpp
+++ b/fide2024/main.cpp
@@ -37,13 +37,13 @@ int main(int argc, char* argv[]) {
   std::cout << engine_info() << std::endl;
 #endif // !KAGGLE
 
-  UCI::init(Options);
+  UCI::init();
   PSQT::init();
   Bitboards::init();
   Position::init();
   Bitbases::init();
   Endgames::init();
-  Threads.set(Options["Threads"]);
+  Threads.set(OptionValue::Threads);
   Search::clear(); // After threads are up
 
   UCI::loop(argc, argv);

--- a/fide2024/position.cpp
+++ b/fide2024/position.cpp
@@ -148,7 +148,7 @@ void Position::init() {
 /// This function is not very robust - make sure that input FENs are correct,
 /// this is assumed to be the responsibility of the GUI.
 
-Position& Position::set(const string& fenStr, bool isChess960, StateInfo* si, Thread* th) {
+Position& Position::set(const string& fenStr, StateInfo* si, Thread* th) {
 /*
    A FEN string defines a particular position using only the ASCII character set.
 
@@ -265,7 +265,6 @@ Position& Position::set(const string& fenStr, bool isChess960, StateInfo* si, Th
   // handle also common incorrect FEN with fullmove = 0.
   gamePly = std::max(2 * (gamePly - 1), 0) + (sideToMove == BLACK);
 
-  chess960 = isChess960;
   thisThread = th;
   set_state(st);
 
@@ -372,7 +371,7 @@ Position& Position::set(const string& code, Color c, StateInfo* si) {
   string fenStr = "8/" + sides[0] + char(8 - sides[0].length() + '0') + "/8/8/8/8/"
                        + sides[1] + char(8 - sides[1].length() + '0') + "/8 w - - 0 10";
 
-  return set(fenStr, false, si, nullptr);
+  return set(fenStr, si, nullptr);
 }
 
 
@@ -405,16 +404,16 @@ const string Position::fen() const {
   ss << (sideToMove == WHITE ? " w " : " b ");
 
   if (can_castle(WHITE_OO))
-      ss << (chess960 ? char('A' + file_of(castling_rook_square(WHITE_OO ))) : 'K');
+      ss << 'K';
 
   if (can_castle(WHITE_OOO))
-      ss << (chess960 ? char('A' + file_of(castling_rook_square(WHITE_OOO))) : 'Q');
+      ss << 'Q';
 
   if (can_castle(BLACK_OO))
-      ss << (chess960 ? char('a' + file_of(castling_rook_square(BLACK_OO ))) : 'k');
+      ss << 'k';
 
   if (can_castle(BLACK_OOO))
-      ss << (chess960 ? char('a' + file_of(castling_rook_square(BLACK_OOO))) : 'q');
+      ss << 'q';
 
   if (!can_castle(ANY_CASTLING))
       ss << '-';
@@ -520,8 +519,7 @@ bool Position::legal(Move m) const {
       // In case of Chess960, verify that when moving the castling rook we do
       // not discover some hidden checker.
       // For instance an enemy queen in SQ_A1 when castling rook is in SQ_B1.
-      return   !chess960
-            || !(attacks_bb<ROOK>(to, pieces() ^ to_sq(m)) & pieces(~us, ROOK, QUEEN));
+      return true;
   }
 
   // If the moving piece is a king, check whether the destination square is
@@ -1207,7 +1205,7 @@ void Position::flip() {
   std::getline(ss, token); // Half and full moves
   f += token;
 
-  set(f, is_chess960(), st, this_thread());
+  set(f, st, this_thread());
 
   assert(pos_is_ok());
 }

--- a/fide2024/position.h
+++ b/fide2024/position.h
@@ -78,7 +78,7 @@ public:
   Position& operator=(const Position&) = delete;
 
   // FEN string input/output
-  Position& set(const std::string& fenStr, bool isChess960, StateInfo* si, Thread* th);
+  Position& set(const std::string& fenStr, StateInfo* si, Thread* th);
   Position& set(const std::string& code, Color c, StateInfo* si);
   const std::string fen() const;
 
@@ -152,7 +152,6 @@ public:
   // Other properties of the position
   Color side_to_move() const;
   int game_ply() const;
-  bool is_chess960() const;
   Thread* this_thread() const;
   bool is_draw(int ply) const;
   bool has_game_cycle(int ply) const;
@@ -194,7 +193,6 @@ private:
   Score psq;
   Thread* thisThread;
   StateInfo* st;
-  bool chess960;
 };
 
 namespace PSQT {
@@ -375,10 +373,6 @@ inline bool Position::opposite_bishops() const {
   return   pieceCount[W_BISHOP] == 1
         && pieceCount[B_BISHOP] == 1
         && opposite_colors(square<BISHOP>(WHITE), square<BISHOP>(BLACK));
-}
-
-inline bool Position::is_chess960() const {
-  return chess960;
 }
 
 inline bool Position::capture_or_promotion(Move m) const {

--- a/fide2024/thread.cpp
+++ b/fide2024/thread.cpp
@@ -110,7 +110,7 @@ void Thread::idle_loop() {
   // some Windows NUMA hardware, for instance in fishtest. To make it simple,
   // just check if running threads are below a threshold, in this case all this
   // NUMA machinery is not needed.
-  if (Options["Threads"] > 8)
+  if (OptionValue::Threads > 8)
       WinProcGroup::bindThisThread(idx);
 
   while (true)
@@ -150,7 +150,7 @@ void ThreadPool::set(size_t requested) {
       clear();
 
       // Reallocate the hash with the new threadpool size
-      TT.resize(Options["Hash"]);
+      TT.resize(OptionValue::Hash);
 
       // Init thread number dependent search params.
       Search::init();
@@ -207,7 +207,7 @@ void ThreadPool::start_thinking(Position& pos, StateListPtr& states,
       th->nodes = th->nmpMinPly = 0;
       th->rootDepth = th->completedDepth = 0;
       th->rootMoves = rootMoves;
-      th->rootPos.set(pos.fen(), pos.is_chess960(), &setupStates->back(), th);
+      th->rootPos.set(pos.fen(), &setupStates->back(), th);
   }
 
   setupStates->back() = tmp;

--- a/fide2024/timeman.cpp
+++ b/fide2024/timeman.cpp
@@ -83,26 +83,10 @@ namespace {
 
 void TimeManagement::init(Search::LimitsType& limits, Color us, int ply) {
 
-  TimePoint minThinkingTime = Options["Minimum Thinking Time"];
-  TimePoint moveOverhead    = Options["Move Overhead"];
-  TimePoint slowMover       = Options["Slow Mover"];
-  TimePoint npmsec          = Options["nodestime"];
+  TimePoint minThinkingTime = OptionValue::MinimumThinkingTime;
+  TimePoint moveOverhead = OptionValue::MoveOverhead;
+  TimePoint slowMover = OptionValue::SlowMover;
   TimePoint hypMyTime;
-
-  // If we have to play in 'nodes as time' mode, then convert from time
-  // to nodes, and use resulting values in time management formulas.
-  // WARNING: to avoid time losses, the given npmsec (nodes per millisecond)
-  // must be much lower than the real engine speed.
-  if (npmsec)
-  {
-      if (!availableNodes) // Only once at game start
-          availableNodes = npmsec * limits.time[us]; // Time is in msec
-
-      // Convert from milliseconds to nodes
-      limits.time[us] = TimePoint(availableNodes);
-      limits.inc[us] *= npmsec;
-      limits.npmsec = npmsec;
-  }
 
   startTime = limits.startTime;
   optimumTime = maximumTime = std::max(limits.time[us], minThinkingTime);
@@ -128,6 +112,6 @@ void TimeManagement::init(Search::LimitsType& limits, Color us, int ply) {
       maximumTime = std::min(t2, maximumTime);
   }
 
-  if (Options["Ponder"])
+  if (OptionValue::Ponder)
       optimumTime += optimumTime / 4;
 }

--- a/fide2024/tt.cpp
+++ b/fide2024/tt.cpp
@@ -87,18 +87,18 @@ void TranspositionTable::clear() {
 
   std::vector<std::thread> threads;
 
-  for (size_t idx = 0; idx < Options["Threads"]; ++idx)
+  for (size_t idx = 0; idx < OptionValue::Threads; ++idx)
   {
       threads.emplace_back([this, idx]() {
 
           // Thread binding gives faster search on systems with a first-touch policy
-          if (Options["Threads"] > 8)
+          if (OptionValue::Threads > 8)
               WinProcGroup::bindThisThread(idx);
 
           // Each thread will zero its part of the hash table
-          const size_t stride = clusterCount / Options["Threads"],
+          const size_t stride = clusterCount / OptionValue::Threads,
                        start  = stride * idx,
-                       len    = idx != Options["Threads"] - 1 ?
+                       len    = idx != OptionValue::Threads - 1 ?
                                 stride : clusterCount - start;
 
           std::memset(&table[start], 0, len * sizeof(Cluster));

--- a/fide2024/uci.h
+++ b/fide2024/uci.h
@@ -28,55 +28,32 @@
 
 class Position;
 
+namespace OptionValue {
+
+    // min: -100, max: 100
+    constexpr int Contempt = 24;
+    constexpr int Threads = 1;
+    // 64bitÇ»ÇÁç≈ëÂ131072ÅA32bitÇ»ÇÁç≈ëÂ2048
+    constexpr int Hash = 16;
+    constexpr bool Ponder = true;
+    constexpr int MultiPV = 1;
+    // min: 0, max: 5000
+    constexpr int MoveOverhead = 30;
+    // min: 0, max: 5000
+    constexpr int MinimumThinkingTime = 20;
+    // min: 10, max: 1000
+    constexpr int SlowMover = 84;
+}
+
 namespace UCI {
-
-class Option;
-
-/// Custom comparator because UCI options should be case insensitive
-struct CaseInsensitiveLess {
-  bool operator() (const std::string&, const std::string&) const;
-};
-
-/// Our options container is actually a std::map
-typedef std::map<std::string, Option, CaseInsensitiveLess> OptionsMap;
-
-/// Option class implements an option as defined by UCI protocol
-class Option {
-
-  typedef void (*OnChange)(const Option&);
-
-public:
-  Option(OnChange = nullptr);
-  Option(bool v, OnChange = nullptr);
-  Option(const char* v, OnChange = nullptr);
-  Option(double v, int minv, int maxv, OnChange = nullptr);
-  Option(const char* v, const char* cur, OnChange = nullptr);
-
-  Option& operator=(const std::string&);
-  void operator<<(const Option&);
-  operator double() const;
-  operator std::string() const;
-  bool operator==(const char*) const;
-
-private:
-  friend std::ostream& operator<<(std::ostream&, const OptionsMap&);
-
-  std::string defaultValue, currentValue, type;
-  int min, max;
-  size_t idx;
-  OnChange on_change;
-};
-
-void init(OptionsMap&);
+void init();
 void loop(int argc, char* argv[]);
 std::string value(Value v);
 std::string square(Square s);
-std::string move(Move m, bool chess960);
+std::string move(Move m);
 std::string pv(const Position& pos, Depth depth, Value alpha, Value beta);
 Move to_move(const Position& pos, std::string& str);
 
 } // namespace UCI
-
-extern UCI::OptionsMap Options;
 
 #endif // #ifndef UCI_H_INCLUDED

--- a/fide2024/ucioption.cpp
+++ b/fide2024/ucioption.cpp
@@ -31,155 +31,18 @@
 
 using std::string;
 
-UCI::OptionsMap Options; // Global object
-
 namespace UCI {
 
 /// 'On change' actions, triggered by an option's value change
-void on_clear_hash(const Option&) { Search::clear(); }
-void on_hash_size(const Option& o) { TT.resize(o); }
-#ifndef KAGGLE
-void on_logger(const Option& o) { start_logger(o); }
-#endif // !KAGGLE
-void on_threads(const Option& o) { Threads.set(o); }
-
-
-/// Our case insensitive less() function as required by UCI protocol
-bool CaseInsensitiveLess::operator() (const string& s1, const string& s2) const {
-
-  return std::lexicographical_compare(s1.begin(), s1.end(), s2.begin(), s2.end(),
-         [](char c1, char c2) { return tolower(c1) < tolower(c2); });
-}
-
+void on_clear_hash() { Search::clear(); }
+void on_hash_size() { TT.resize(OptionValue::Hash); }
+void on_threads() { Threads.set(OptionValue::Threads); }
 
 /// init() initializes the UCI options to their hard-coded default values
-
-void init(OptionsMap& o) {
-
-  // at most 2^32 clusters.
-  constexpr int MaxHashMB = Is64Bit ? 131072 : 2048;
-#ifndef KAGGLE
-  o["Debug Log File"]        << Option("", on_logger);
-#endif // !KAGGLE
-  o["Contempt"]              << Option(24, -100, 100);
-  o["Analysis Contempt"]     << Option("Both var Off var White var Black var Both", "Both");
-  o["Threads"]               << Option(1, 1, 1, on_threads);
-  o["Hash"]                  << Option(16, 1, MaxHashMB, on_hash_size);
-  o["Clear Hash"]            << Option(on_clear_hash);
-  o["Ponder"]                << Option(false);
-  o["MultiPV"]               << Option(1, 1, 500);
-  o["Move Overhead"]         << Option(30, 0, 5000);
-  o["Minimum Thinking Time"] << Option(20, 0, 5000);
-  o["Slow Mover"]            << Option(84, 10, 1000);
-  o["nodestime"]             << Option(0, 0, 10000);
-  o["UCI_Chess960"]          << Option(false);
-  o["UCI_AnalyseMode"]       << Option(false);
-}
-
-
-/// operator<<() is used to print all the options default values in chronological
-/// insertion order (the idx field) and in the format defined by the UCI protocol.
-
-std::ostream& operator<<(std::ostream& os, const OptionsMap& om) {
-
-  for (size_t idx = 0; idx < om.size(); ++idx)
-      for (const auto& it : om)
-          if (it.second.idx == idx)
-          {
-              const Option& o = it.second;
-              os << "\noption name " << it.first << " type " << o.type;
-
-              if (o.type == "string" || o.type == "check" || o.type == "combo")
-                  os << " default " << o.defaultValue;
-
-              if (o.type == "spin")
-                  os << " default " << int(stof(o.defaultValue))
-                     << " min "     << o.min
-                     << " max "     << o.max;
-
-              break;
-          }
-
-  return os;
-}
-
-
-/// Option class constructors and conversion operators
-
-Option::Option(const char* v, OnChange f) : type("string"), min(0), max(0), on_change(f)
-{ defaultValue = currentValue = v; }
-
-Option::Option(bool v, OnChange f) : type("check"), min(0), max(0), on_change(f)
-{ defaultValue = currentValue = (v ? "true" : "false"); }
-
-Option::Option(OnChange f) : type("button"), min(0), max(0), on_change(f)
-{}
-
-Option::Option(double v, int minv, int maxv, OnChange f) : type("spin"), min(minv), max(maxv), on_change(f)
-{ defaultValue = currentValue = std::to_string(v); }
-
-Option::Option(const char* v, const char* cur, OnChange f) : type("combo"), min(0), max(0), on_change(f)
-{ defaultValue = v; currentValue = cur; }
-
-Option::operator double() const {
-  assert(type == "check" || type == "spin");
-  return (type == "spin" ? stof(currentValue) : currentValue == "true");
-}
-
-Option::operator std::string() const {
-  assert(type == "string");
-  return currentValue;
-}
-
-bool Option::operator==(const char* s) const {
-  assert(type == "combo");
-  return   !CaseInsensitiveLess()(currentValue, s)
-        && !CaseInsensitiveLess()(s, currentValue);
-}
-
-
-/// operator<<() inits options and assigns idx in the correct printing order
-
-void Option::operator<<(const Option& o) {
-
-  static size_t insert_order = 0;
-
-  *this = o;
-  idx = insert_order++;
-}
-
-
-/// operator=() updates currentValue and triggers on_change() action. It's up to
-/// the GUI to check for option's limits, but we could receive the new value
-/// from the user by console window, so let's check the bounds anyway.
-
-Option& Option::operator=(const string& v) {
-
-  assert(!type.empty());
-
-  if (   (type != "button" && v.empty())
-      || (type == "check" && v != "true" && v != "false")
-      || (type == "spin" && (stof(v) < min || stof(v) > max)))
-      return *this;
-
-  if (type == "combo")
-  {
-      OptionsMap comboMap; // To have case insensitive compare
-      string token;
-      std::istringstream ss(defaultValue);
-      while (ss >> token)
-          comboMap[token] << Option();
-      if (!comboMap.count(v) || v == "var")
-          return *this;
-  }
-
-  if (type != "button")
-      currentValue = v;
-
-  if (on_change)
-      on_change(*this);
-
-  return *this;
+void init() {
+  on_threads();
+  on_hash_size();
+  on_clear_hash();
 }
 
 } // namespace UCI


### PR DESCRIPTION
https://www.kaggle.com/code/yamashitamotokazu/fide2024-stockfish-compile-without-syzygy7

ucioptionをmapで扱うのではなく定数に変更した
chess960は使わないので、chess960は削除した
loggerも削除した
圧縮した後の実行ファイルサイズが82KBから75KBになった